### PR TITLE
Fix reporting on same repo multiple times

### DIFF
--- a/src/issues/producer.rs
+++ b/src/issues/producer.rs
@@ -1,5 +1,6 @@
 //! Module implementing the suggested issues producer.
 
+use std::collections::HashSet;
 use std::env;
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -78,6 +79,7 @@ impl SuggestedIssuesProducer {
         // Determine the GitHub repositories corresponding to dependent crates.
         // In most cases, this means read the package/repository entries
         // from the manifests of those crates by talking to crates.io.
+        let mut repo_set = HashSet::new();
         let repos = {
             let manifest_path = manifest_path.to_owned();
             let crates_io = self.crates_io.clone();
@@ -85,7 +87,15 @@ impl SuggestedIssuesProducer {
                 .and_then(move |dep| {
                     repo_for_dependency(&manifest_path, &crates_io, &dep).map_err(Error::CratesIo)
                 })
-                .filter_map(|opt_repo| opt_repo)
+                .filter_map(move |opt_repo| {
+                    if let Some(repo) = opt_repo {
+                        // Check if we've reported on this repo already.
+                        if repo_set.contains(&repo) { None }
+                        else {
+                            repo_set.insert(repo.clone()); Some(repo)
+                        }
+                    } else { None }
+                })
         };
 
         // For each repo, search for suitable issues and stream them in a round-robin fashion

--- a/src/model/github.rs
+++ b/src/model/github.rs
@@ -10,7 +10,7 @@ const GITHUB_HOST: &'static str = "github.com";
 
 
 /// Represents a GitHub repository.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Repository {
     pub owner: String,
     pub name: String,


### PR DESCRIPTION
Fixing Issue #2. 

The problem was simple: The `num-rational`, `num-traits`, and `num-bigint` crates lived in a shared repo, so they all had their `repository` values set to `rust-num/num`. These crates have already been moved into their own repos so this specific instance of the problem should stop occurring soon, but I implemented a general fix that simply prevents the same repo from being reported on multiple times.

I've confirmed that the issue no longer appears when I run `cargo contribute -v` on my crate, [over](github.com/m-cat/over).